### PR TITLE
Remove rackup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ WebSockets?
 6. Set your RACK_ENV (e.g. `export RACK_ENV='development'`)
 7. `bundle exec rake db:migrate` to load the database schema into the database
 8. Change the API password (:gifmachine_password) in app.rb to something else
-9. `rackup`
+9. `ruby app.rb`
 10. Browse to `http://localhost:9292`
 
 

--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,7 @@ require './models/gif'
 
 set :server, 'thin'
 set :sockets, []
+set :logger, Logger.new(STDOUT)
 
 configure do
   set :gifmachine_password, ENV.fetch('GIFMACHINE_PASSWORD', 'password123')

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,0 @@
-require './app'
-run Sinatra::Application


### PR DESCRIPTION
Remove `rackup` so you just will run `ruby app.rb` instead to run the server

prime @mattsmith0308 