### PR TITLE
Add initial db migration

### DIFF
--- a/db/migrate/20200224212737_init.rb
+++ b/db/migrate/20200224212737_init.rb
@@ -1,0 +1,11 @@
+class Init < ActiveRecord::Migration[6.0]
+  def change
+    create_table "gifs", force: :cascade do |t|
+      t.string "url"
+      t.string "who"
+      t.datetime "when"
+      t.string "meme_top"
+      t.string "meme_bottom"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2014_08_27_215941) do
+ActiveRecord::Schema.define(version: 2020_02_24_212737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
prime @joshbranham

```
[staging]~/Repos/gifmachine (add-migration %)$ rake db:drop
Dropped database 'gifmachine'
[staging]~/Repos/gifmachine (add-migration %)$ rake db:create
Created database 'gifmachine'
[staging]~/Repos/gifmachine (add-migration %)$ rake db:migrate
== 20200224212737 Init: migrating =============================================
-- create_table("gifs", {:force=>:cascade})
   -> 0.0073s
== 20200224212737 Init: migrated (0.0074s) ====================================
```